### PR TITLE
 Fix: getAdSet response have a data object instead of array

### DIFF
--- a/criteo_marketing_transition/models/response_read_ad_set.py
+++ b/criteo_marketing_transition/models/response_read_ad_set.py
@@ -31,7 +31,7 @@ class ResponseReadAdSet(object):
                             and the value is json key in definition.
     """
     openapi_types = {
-        'data': 'list[ReadModelReadAdSet]',
+        'data': 'ReadModelReadAdSet',
         'warnings': 'list[ProblemDetails]',
         'errors': 'list[ProblemDetails]'
     }
@@ -63,7 +63,7 @@ class ResponseReadAdSet(object):
 
 
         :return: The data of this ResponseReadAdSet.  # noqa: E501
-        :rtype: list[ReadModelReadAdSet]
+        :rtype: ReadModelReadAdSet
         """
         return self._data
 
@@ -73,7 +73,7 @@ class ResponseReadAdSet(object):
 
 
         :param data: The data of this ResponseReadAdSet.  # noqa: E501
-        :type: list[ReadModelReadAdSet]
+        :type: ReadModelReadAdSet
         """
 
         self._data = data

--- a/docs/ResponseReadAdSet.md
+++ b/docs/ResponseReadAdSet.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**data** | [**list[ReadModelReadAdSet]**](ReadModelReadAdSet.md) |  | [optional] 
+**data** | [**ReadModelReadAdSet**](ReadModelReadAdSet.md) |  | [optional] 
 **warnings** | [**list[ProblemDetails]**](ProblemDetails.md) |  | [optional] 
 **errors** | [**list[ProblemDetails]**](ProblemDetails.md) |  | [optional] 
 


### PR DESCRIPTION
The ResponseReadAdSet model wasn't properly created and should have the data attribute to be an object instead of an array.